### PR TITLE
NGINX compatible and minor fixes

### DIFF
--- a/Analyzer/checkServer.sh
+++ b/Analyzer/checkServer.sh
@@ -40,7 +40,7 @@ function testssl.sh {
     cd $testssl_folder
     s_echo "version: $version"
     s_echo "Analyzing..."
-    bash testssl.sh $args $1:$2 | aha -t ${FUNCNAME[0]} > $report/testssl_report.html
+    yes NO | bash testssl.sh $args $1:$2 | aha -t ${FUNCNAME[0]} > $report/testssl_report.html
     s_echo "Report generated successfully!"
     echo
     cd $root_folder

--- a/Evaluator/Mitigations/3SHAKE.xml
+++ b/Evaluator/Mitigations/3SHAKE.xml
@@ -9,6 +9,7 @@ The attack leads to a client impersonation that, by breaking both confidentialit
 		<Textual>The only acceptable mitigation is to use the `extended_master_secret` TLS extension. For this reason it is recommended to update the TLS library to a version that supports the aforementioned extension (e.g. OpenSSL v1.1.0+).</Textual>
 		<Snippet>
 			<apache>No snippet available</apache>
+			<nginx>No snippet available</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/BREACH.xml
+++ b/Evaluator/Mitigations/BREACH.xml
@@ -17,6 +17,38 @@
 	3. comment or delete it.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+
+			<nginx>In a default situation, you can edit your website configuration */etc/nginx/sites-avaliable/default*
+	(if you changed your site conf name */etc/nginx/sites-avaliable/YOURSITECONFIGURATION*);
+
+- Do the following:
+	1. Edit this file with an editor;
+	2. add in your server configuration the string `gzip off;`. 
+	If not missing, set it off by changing `gzip on;` to `gzip off;`
+
+- Example: 
+	*For example, assuming this is your configuration:*
+
+
+		server{
+			gzip on;
+		}
+
+
+	Change it in:
+
+
+		server{
+			gzip off;
+		}
+
+
+	If missing, just add `gzip off;` inside brackets.
+
+**This should be a fast temporary measure**, use https://github.com/nulab/nginx-length-hiding-filter-module instead.
+
+*Disabling gzip will disable compression in your website.*
+			</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/BREACH.xml
+++ b/Evaluator/Mitigations/BREACH.xml
@@ -18,8 +18,8 @@
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
 
-			<nginx>In a default situation, you can edit your website configuration */etc/nginx/sites-avaliable/default*
-	(if you changed your site conf name */etc/nginx/sites-avaliable/YOURSITECONFIGURATION*);
+			<nginx>In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
 
 - Do the following:
 	1. Edit this file with an editor;
@@ -47,7 +47,7 @@ N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
 
 N.B. restart the server by typing: `sudo service nginx restart`.
 
-**This should be a fast temporary measure**, use [this](https://github.com/nulab/nginx-length-hiding-filter-module) instead.
+**However this should be a fast temporary measure**, use [this](https://github.com/nulab/nginx-length-hiding-filter-module) instead.
 
 *Disabling gzip will disable compression in your website.*
 			</nginx>

--- a/Evaluator/Mitigations/BREACH.xml
+++ b/Evaluator/Mitigations/BREACH.xml
@@ -45,7 +45,9 @@ N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
 
 	If missing, just add `gzip off;` inside brackets.
 
-**This should be a fast temporary measure**, use https://github.com/nulab/nginx-length-hiding-filter-module instead.
+N.B. restart the server by typing: `sudo service nginx restart`.
+
+**This should be a fast temporary measure**, use [this](https://github.com/nulab/nginx-length-hiding-filter-module) instead.
 
 *Disabling gzip will disable compression in your website.*
 			</nginx>

--- a/Evaluator/Mitigations/CRIME.xml
+++ b/Evaluator/Mitigations/CRIME.xml
@@ -13,6 +13,12 @@
    - if not, add the line `SSLCompression off` within the file.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+			<nginx>SSL compression is turned off by default in nginx 1.1.6+/1.0.9+ (if OpenSSL 1.0.0+ used) and nginx 1.3.2+/1.2.2+ (if older versions of OpenSSL are used).
+
+- If you are using al earlier version of nginx or OpenSSL and your distro has not backported this option then you need to 
+	1. **update to the last version** or
+	2. recompile OpenSSL without ZLIB support.
+			</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/DROWN.xml
+++ b/Evaluator/Mitigations/DROWN.xml
@@ -13,6 +13,14 @@
    - otherwise, add `-SSLv2` at the end of the line.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_protocols`;
+3. Remove `SSLv2` (if any). Make sure you have atleast another TLS protocol. If you can't find `ssl_protocols` you should be fine if your NGINX is updated.
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/HSTS_not_preloaded.xml
+++ b/Evaluator/Mitigations/HSTS_not_preloaded.xml
@@ -6,6 +6,7 @@
 		<Textual>Submit the request to [HSTSPreload.org](https://hstspreload.org).</Textual>
 		<Snippet>
 			<apache>No snippet available</apache>
+			<nginx>No snippet available</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/HSTS_not_set.xml
+++ b/Evaluator/Mitigations/HSTS_not_set.xml
@@ -9,6 +9,13 @@
 2. add the line `Header always set Strict-Transport-Security "max-age=31536000"`.
 
 N.B. restart the server by typing: `sudo service apache2 restart` and be sure that `mod_headers` is enabled.</apache>
+			<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Add inside `server{...}` brackets: `add_header Strict-Transport-Security "max-age=31536000; includeSubdomains; preload";`
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+			</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/HTTPS_not_enforced.xml
+++ b/Evaluator/Mitigations/HTTPS_not_enforced.xml
@@ -12,6 +12,20 @@
 3. add the string `Redirect / https://website` where "website" is the URL you want to point the users to (e.g. www.fbk.eu).
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. add 
+	
+		server {
+    	listen 80 default_server;
+    	server_name _;
+    	return 301 https://$host$request_uri;
+		}
+3. remove ALL other `listen 80` inside `server{...}` brackets (except for the previous one)
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/LUCKY13.xml
+++ b/Evaluator/Mitigations/LUCKY13.xml
@@ -9,6 +9,16 @@ The attack, by breaching in the authentication mechanism, has a serious impact o
 		<Textual>Update the TLS library to a version that contains the custom mitigations (e.g. OpenSSL v1.0.2h+).</Textual>
 		<Snippet>
 			<apache>No snippet available</apache>
+			<nginx>The best mitigation is to update the OpenSSL libraries. The fastest mitigation is to disable all CBC ciphers.
+			
+1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
+3. Remove any CBC-related cipher (even nested one).
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/MITZVAH.xml
+++ b/Evaluator/Mitigations/MITZVAH.xml
@@ -15,7 +15,7 @@ N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
 <nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
 	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
 2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
-3. Remove **RC4** (if any) and add **:!RC4** at the end. 
+3. Remove `RC4` (if any) and add `:!RC4` at the end. 
 
 
 N.B. restart the server by typing: `sudo service nginx restart`.

--- a/Evaluator/Mitigations/MITZVAH.xml
+++ b/Evaluator/Mitigations/MITZVAH.xml
@@ -12,6 +12,14 @@
 3. add the string `:!RC4` at the end.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
+3. Remove **RC4** (if any) and add **:!RC4** at the end. 
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/NOMORE.xml
+++ b/Evaluator/Mitigations/NOMORE.xml
@@ -12,6 +12,14 @@
 3. add the string `:!RC4` at the end.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
+3. Remove **RC4** (if any) and add **:!RC4** at the end.
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/NOMORE.xml
+++ b/Evaluator/Mitigations/NOMORE.xml
@@ -15,7 +15,7 @@ N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
 <nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
 	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
 2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
-3. Remove **RC4** (if any) and add **:!RC4** at the end.
+3. Remove `RC4` (if any) and add `:!RC4` at the end.
 
 
 N.B. restart the server by typing: `sudo service nginx restart`.

--- a/Evaluator/Mitigations/POODLE.xml
+++ b/Evaluator/Mitigations/POODLE.xml
@@ -13,6 +13,14 @@
    - otherwise, add `-SSLv3` at the end of the line.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_protocols`;
+3. Remove `SSLv3` (if any). Make sure you have atleast another TLS protocol. If you can't find `ssl_protocols` you should be fine if your NGINX is updated.
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/RENEGOTIATION.xml
+++ b/Evaluator/Mitigations/RENEGOTIATION.xml
@@ -8,6 +8,7 @@
 		<Textual>Update the TLS library to a version that allows renegotiation disabling (e.g. OpenSSL v1.1.1+).</Textual>
 		<Snippet>
 			<apache>No snippet available</apache>
+			<nginx>No snippet available</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/ROBOT.xml
+++ b/Evaluator/Mitigations/ROBOT.xml
@@ -12,6 +12,14 @@
 3. add the string `:!RSA` at the end.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
+3. Remove `RSA` (if any) and add `:!RSA` at the end. 
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/SLOTH.xml
+++ b/Evaluator/Mitigations/SLOTH.xml
@@ -8,6 +8,7 @@
 		<Textual>Update the TLS library to a version that contains the custom mitigations (e.g. OpenSSL v1.0.1f+).</Textual>
 		<Snippet>
 			<apache>No snippet available</apache>
+			<nginx>No snippet available</nginx><!--check if !MD5 can fix that-->
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/SWEET32.xml
+++ b/Evaluator/Mitigations/SWEET32.xml
@@ -13,6 +13,16 @@
 3. add the string `:!3DES` at the end.
 
 N.B. restart the server by typing: `sudo service apache2 restart`.</apache>
+<nginx>1. In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+2. Inside `server {...}` brackets configuration, find `ssl_ciphers`;
+3. Remove **3DES** (if any) and add **:!3DES** at the end. 
+4. Re run this tool. If it appears again,  Remove **IDEA** (if any) and add **:!IDEA** at the end. 
+5. Re run this tool. If it appears again,  Remove **RSA** (if any) and add **:!RSA** at the end.<!--Because it contains IDEA and DES-->
+
+
+N.B. restart the server by typing: `sudo service nginx restart`.
+</nginx>
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/TRANSPARENCY.xml
+++ b/Evaluator/Mitigations/TRANSPARENCY.xml
@@ -30,7 +30,7 @@ N.B. restart the server by typing: `sudo service apache2 restart` and make sure 
 	ssl_stapling_verify on;
 	
 2. Restart your server with `sudo service nginx restart` and make sure that your certificate has been logged (check at [crt.sh](https://crt.sh) ).
-
+</nginx>
 
 		</Snippet>
 	</Mitigation>

--- a/Evaluator/Mitigations/TRANSPARENCY.xml
+++ b/Evaluator/Mitigations/TRANSPARENCY.xml
@@ -17,6 +17,21 @@
     - SSLStaplingCache shmcb:/var/run/ocsp(128000)
 
 N.B. restart the server by typing: `sudo service apache2 restart` and make sure that your certificate has been logged (check at [crt.sh](https://crt.sh) ).</apache>
+			<nginx>In a default situation, you can edit your website configuration */etc/nginx/sites-enabled/default*
+	(if you changed your site conf name */etc/nginx/sites-enabled/YOURSITECONFIGURATION*);
+	
+1. Add the following to your server configuration:
+	ssl_session_cache shared:SSL:5m;
+
+  	ssl_session_timeout 5m;
+	
+	ssl_stapling on;
+  	
+	ssl_stapling_verify on;
+	
+2. Restart your server with `sudo service nginx restart` and make sure that your certificate has been logged (check at [crt.sh](https://crt.sh) ).
+
+
 		</Snippet>
 	</Mitigation>
 </Entry>

--- a/Evaluator/Mitigations/simulateReport.sh
+++ b/Evaluator/Mitigations/simulateReport.sh
@@ -19,5 +19,10 @@ xmllint --xpath "/Entry/Mitigation/Textual/text()" $1 >> $report
 printf "\n\n" >> $report
 #~ Snippet
 #~ Apache
-xmllint --xpath "/Entry/Mitigation/Snippet/Apache/text()" $1 >> $report
+printf "APACHE\n" >> $report
+xmllint --xpath "/Entry/Mitigation/Snippet/apache/text()" $1 >> $report
+printf "\n\n" >> $report
+#~ Nginx
+printf "NGINX\n" >> $report
+xmllint --xpath "/Entry/Mitigation/Snippet/nginx/text()" $1 >> $report
 printf "\n\n" >> $report


### PR DESCRIPTION
# PR
## Tested Vulnerabilities Fixes
- BREACH
- LUCKY13
- MITZVAH
- NOMORE RC4
- SWEET32
- HTTPS_not_enforced


## Untested Vulnerabilities Fixes
### Untested because makes no sense to test them
- 3SHAKE _(requires OpenSSL update)_
- Renegotiation  _(disables renegotiation library side)_
- SLOTH  _(requires OpenSSL update)_
- HSTS_not_preloaded  _(it isn't NGINX Side)_

### Untested because couldn't test them

SSLv2 and SSLv3 won't work 
No issues on deployment but analysis stage(testssl.sh) says there's no SSLv3 or SSLv2 protocol (even if enabled).


- DROWN _(uses SSLv2, easy as it is just disable it)_
- POODLE _(uses SSLv3, easy as it is just disable it)_
- CRIME _(It's fixed on newer NGINX and OpenSSL)_
- ROBOT _(couldn't reproduce it, i converted the APACHE version to NGINX side)_

#### Couldn't reproduce it because i'm testing locally and i'm not using a domain
_(I do not have a certificate to try with)_

- TRANSPARENCY _(couldn't reproduce it, i converted the APACHE version to NGINX side)_
- HSTS_not_set _(couldn't reproduce it, i converted the APACHE version to NGINX side)_


## Other Fixes

### Skip `yes` prompt on testssl.sh [269096f](https://github.com/stfbk/tlsassistant/commit/269096f3b28d505e1ab864b216657dabcff92119)

If the configuration is wrong and testssl.sh can't obtain any ciphers, it will WAIT until the user confirm with "yes" to proceed.

This stops the execution of the bash script.
Fixed with
`yes NO | bash ...`.

This will SKIP entirely testssl.sh check if this happens.

changing it to `yes YES|bash...` will confirm and proceed even if it couldn't find any cipher.

### Added NGINX report simulation TAG [9fe24b8](https://github.com/stfbk/tlsassistant/commit/9fe24b8ac9c8cfa75fb4e8ddaf5f9ad54be1179d)

I noticed some error with `xmllint`, so i fixed them and added nginx compatible xmllint parse.


