### PR TITLE
Fix Google HSTS dependency url 404

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -5,7 +5,7 @@
   },
   {
     "type": "cfg",
-    "url": "https://chromium.googlesource.com/chromium/src/net/+/master/http/transport_security_state_static.json?format=TEXT"
+    "url": "https://chromium.googlesource.com/chromium/src/net/+/main/http/transport_security_state_static.json?format=TEXT"
   },
   {
     "type": "cfg",


### PR DESCRIPTION
Branch name changed from `master` to `main`, old link returns 404