### PR TITLE
Fix missing javadoc command on docker image build

### DIFF
--- a/dependencies.json
+++ b/dependencies.json
@@ -45,6 +45,10 @@
   },
   {
     "type": "apt",
+    "url": "default-jdk"
+  },
+  {
+    "type": "apt",
     "url": "maven"
   },
   {


### PR DESCRIPTION
It seems that the build of the docker image fails with the following error because of the `javadoc` command is provided by the `jdk` package and not by the `jre` package.
Adding the `default-jdk` dependency fixes the issue.

![image](https://github.com/stfbk/tlsassistant/assets/24813315/63f6dbb3-1e92-454c-ad30-25c0fcf4cf12)
[tlsa_docker-image-build-fail.log](https://github.com/stfbk/tlsassistant/files/14841251/tlsa_docker-image-build-fail.log)
