### PR TITLE
Add gh action to build and publish image on tag 🏷️

### DIFF
--- a/.github/workflows/ghcr_on_tag.yaml
+++ b/.github/workflows/ghcr_on_tag.yaml
@@ -1,0 +1,27 @@
+name: Build and Push Docker Image
+
+permissions:
+  contents: read
+  packages: write
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Build docker image
+        run: docker build -t ghcr.io/${{ github.repository }}:${{ github.ref_name }} .
+
+      - name: Push Docker image to ghcr
+        run: |
+          # Log in to GitHub Container Registry and push the image
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin && \
+          docker push ghcr.io/${{ github.repository }}:${{ github.ref_name }}


### PR DESCRIPTION
This PR adds a github action that, whenever a new tag is created, builds and publishes the tlsassistant Docker image to github packages (which is [free for public repos](https://docs.github.com/en/billing/managing-billing-for-github-packages/about-billing-for-github-packages#about-billing-for-github-packages))

If you decide to integrate it, it would be nice if you could create a new tag after merging -not necessarily a release- like v3.0.1 so that one image is built and published.

Happy to discuss things further if you have any reserves