### PR TITLE
Update Dockerfile fix LegacyKeyValueFormat warning

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ ENV PATH="/root/.local/bin:$PATH"
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-ENV LANG en_US.UTF-8  
+ENV LANG=en_US.UTF-8
 
-ENV LANGUAGE en_US:en  
+ENV LANGUAGE=en_US:en
 
-ENV LC_ALL en_US.UTF-8    
+ENV LC_ALL=en_US.UTF-8
 
-ENV TZ Europe/Rome
+ENV TZ=Europe/Rome
 
 RUN apt-get update && apt-get install -y git python3-dev python3-pip sudo bsdmainutils locales dnsutils tzdata keyboard-configuration pipx
 
@@ -32,7 +32,7 @@ WORKDIR "/tlsassistant"
 
 RUN poetry install
 
-ENV TLSA_IN_A_DOCKER_CONTAINER Yes
+ENV TLSA_IN_A_DOCKER_CONTAINER=Yes
 
 RUN poetry run python3 install.py -v
 


### PR DESCRIPTION
LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format